### PR TITLE
Adding an edge version of the config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@ inherit_gem:
     - config/default.yml
 ```
 
+### Using the latest Rubocop version
+
+To use the latest version of Rubocop just use the edge config files:
+
+In your .rubocop.yml
+
+```yml
+inherit_gem:
+  rubocop-rootstrap:
+    - config/default_edge.yml
+```
+
+Or for Rails apps
+
+```yml
+inherit_gem:
+  rubocop-rootstrap:
+    - config/rails_edge.yml
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/rootstrap/rubocop-rootstrap. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/rootstrap/rubocop-rootstrap/blob/master/CODE_OF_CONDUCT.md).

--- a/config/default.yml
+++ b/config/default.yml
@@ -66,37 +66,3 @@ Style/ModuleFunction:
 
 Style/ReturnNil:
   Enabled: true
-
-#
-# New cops that are not configured by default
-#
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: false
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: false
-
-Style/SlicingWithRange:
-  Enabled: false

--- a/config/default_edge.yml
+++ b/config/default_edge.yml
@@ -1,0 +1,31 @@
+inherit_from: default.yml
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: false
+
+Style/SlicingWithRange:
+  Enabled: false

--- a/config/rails_edge.yml
+++ b/config/rails_edge.yml
@@ -1,0 +1,3 @@
+require: rubocop-rails
+
+inherit_from: default_edge.yml


### PR DESCRIPTION
This is to support existing projects with outdated Rubocop versions
while at the same time supporting projects with the latest Rubocop
and providing them the default config for the new cops