### PR TITLE
Fix/config files

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,7 +1,3 @@
-AllCops:
-  Exclude:
-    - node_modules/**/*
-
 Documentation:
   Enabled: false
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - node_modules/**/*
+
 Documentation:
   Enabled: false
 

--- a/config/default_rails.yml
+++ b/config/default_rails.yml
@@ -1,0 +1,25 @@
+Rails:
+  Enabled: true
+
+AllCops:
+  Exclude:
+    - db/schema.rb
+
+Layout/SpaceBeforeFirstArg:
+  Exclude:
+    - app/views/api/**/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - config/**/*
+    - spec/**/*
+    - app/admin/**/*
+
+Rails/Delegate:
+  Enabled: true
+
+Rails/FilePath:
+  Enabled: false
+
+Rails/SaveBang:
+  Enabled: true

--- a/config/default_rails.yml
+++ b/config/default_rails.yml
@@ -4,6 +4,7 @@ Rails:
 AllCops:
   Exclude:
     - db/schema.rb
+    - node_modules/**/*
 
 Layout/SpaceBeforeFirstArg:
   Exclude:

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,29 +1,5 @@
 require: rubocop-rails
 
-inherit_from: default.yml
-
-Rails:
-  Enabled: true
-
-AllCops:
-  Exclude:
-    - db/schema.rb
-
-Layout/SpaceBeforeFirstArg:
-  Exclude:
-    - app/views/api/**/**/*
-
-Metrics/BlockLength:
-  Exclude:
-    - config/**/*
-    - spec/**/*
-    - app/admin/**/*
-
-Rails/Delegate:
-  Enabled: true
-
-Rails/FilePath:
-  Enabled: false
-
-Rails/SaveBang:
-  Enabled: true
+inherit_from:
+  - default.yml
+  - default_rails.yml

--- a/config/rails_edge.yml
+++ b/config/rails_edge.yml
@@ -1,3 +1,5 @@
 require: rubocop-rails
 
-inherit_from: default_edge.yml
+inherit_from:
+  - default_edge.yml
+  - default_rails.yml


### PR DESCRIPTION
This PR adds 

- The exclusion of `node_modules` to `default.yml`.
- Basic Rails rules to `rails_edge.yml`.
- Extraction of `rails.yml` rules to `default_rails.yml`, this prevents the duplication of inheritance on `rails_edge.yml` if we inherit from `rails.yml` and `default_edge.yml` (because two configurations inherit from `default.yml`).