### PR TITLE
Fix gemspec rubocop version

### DIFF
--- a/rubocop-rootstrap.gemspec
+++ b/rubocop-rootstrap.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   #
   # 0.72 removed rubocop-rails from the main rubocop project
   #
-  spec.add_dependency 'rubocop', '>= 0.72'
+  spec.add_runtime_dependency 'rubocop', '~> 0.72'
 
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9.0'


### PR DESCRIPTION
This PR fixes the next warning:

```
WARNING:  open-ended dependency on rubocop (>= 0.72) is not recommended
  if rubocop is semantically versioned, use:
    add_runtime_dependency 'rubocop', '~> 0.72'
```