### PR TITLE
Limit rubocop version to 0.85 maximum

### DIFF
--- a/rubocop-rootstrap.gemspec
+++ b/rubocop-rootstrap.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   #
   # 0.72 removed rubocop-rails from the main rubocop project
   #
-  spec.add_runtime_dependency 'rubocop', '~> 0.72'
+  spec.add_runtime_dependency 'rubocop', ['>= 0.72', '<= 0.85']
 
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9.0'


### PR DESCRIPTION
### What changes does this PR?

Our custom cops support the rubocop 0.85 at maximum using the edge configurations, so we have to limit this rubocop version in the `gemspec`, otherwise, warnings will be shown in the console.