### PR TITLE
Increment gem version

### DIFF
--- a/rubocop-rootstrap.gemspec
+++ b/rubocop-rootstrap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-rootstrap'
-  spec.version       = '0.1.0'
+  spec.version       = '0.1.1'
   spec.authors       = ['Rootstrap']
   spec.email         = ['info@rootstrap.com']
 


### PR DESCRIPTION
This PR increases the version of the gem to be ready to publish

Ref: https://github.com/rootstrap/rubocop-rootstrap/pull/7