### PR TITLE
Bump rubocop, configure new cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,11 +1,17 @@
-Documentation:
-  Enabled: false
-
 Layout/ClassStructure:
   Enabled: true
 
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
+
+Layout/LineLength:
+  Max: 100
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
 
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: false
@@ -84,15 +90,6 @@ Metrics/ModuleLength:
   CountComments: false
   Max: 200
 
-Metrics/LineLength:
-  Max: 100
-  # To make it possible to copy or click on URIs in the code, we allow lines
-  # containing a URI to be longer than Max.
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
-
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: true
@@ -115,6 +112,9 @@ Style/BlockDelimiters:
   
 Style/CaseLikeIf:
   Enabled: true
+
+Style/Documentation:
+  Enabled: false
 
 Style/ExpandPathArguments:
   Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,9 +1,3 @@
-Layout/ClassStructure:
-  Enabled: true
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
 Layout/LineLength:
   Max: 100
   # To make it possible to copy or click on URIs in the code, we allow lines
@@ -12,51 +6,6 @@ Layout/LineLength:
   URISchemes:
     - http
     - https
-
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: false
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: false
-
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-Lint/DuplicateRescueException:
-  Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: true
-
-Lint/FloatComparison:
-  Enabled: true
-
-Lint/MissingSuper:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/OutOfRangeRegexpRef:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: false
-
-Lint/SelfAssignment:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: false
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-Lint/UnreachableLoop:
-  Enabled: true
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
@@ -97,21 +46,8 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 12
 
-Style/AccessorGrouping:
-  Enabled: true
-  EnforcedStyle: grouped
-
-Style/ArrayCoercion:
-  Enabled: true
-
-Style/BisectedAttrAccessor:
-  Enabled: true
-
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
-  
-Style/CaseLikeIf:
-  Enabled: true
 
 Style/Documentation:
   Enabled: false
@@ -119,64 +55,11 @@ Style/Documentation:
 Style/ExpandPathArguments:
   Enabled: false
 
-Style/ExplicitBlockArgument:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-  EnforcedStyle: scientific
-
 Style/FrozenStringLiteralComment:
-  Enabled: false
-  
-Style/GlobalStdStream:
-  Enabled: false
-
-Style/HashAsLastArrayItem:
-  Enabled: true
-
-Style/HashLikeCase:
-  Enabled: true 
-  MinBranchesCount: 4
-
-Style/HashEachMethods:
-  Enabled: false
-
-Style/HashTransformKeys:
-  Enabled: false
-
-Style/HashTransformValues:
   Enabled: false
 
 Style/ModuleFunction:
   Enabled: false
-  
-Style/OptionalBooleanParameter:
-  Enabled: true
-
-Style/RedundantAssignment:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: false
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: false
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: false
-
-Style/RedundantRegexpEscape:
-  Enabled: true
 
 Style/ReturnNil:
   Enabled: true
-  
-Style/SingleArgumentDig:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: false
-
-Style/StringConcatenation:
-  Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,54 @@ Documentation:
 Layout/ClassStructure:
   Enabled: true
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: false
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: false
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
@@ -52,17 +100,83 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 12
 
+Style/AccessorGrouping:
+  Enabled: true
+  EnforcedStyle: grouped
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
+  
+Style/CaseLikeIf:
+  Enabled: true
 
 Style/ExpandPathArguments:
   Enabled: false
 
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+  EnforcedStyle: scientific
+
 Style/FrozenStringLiteralComment:
+  Enabled: false
+  
+Style/GlobalStdStream:
+  Enabled: false
+
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+Style/HashLikeCase:
+  Enabled: true 
+  MinBranchesCount: 4
+
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
   Enabled: false
 
 Style/ModuleFunction:
   Enabled: false
+  
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: false
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
+  Enabled: true
 
 Style/ReturnNil:
   Enabled: true
+  
+Style/SingleArgumentDig:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false

--- a/config/default_edge.yml
+++ b/config/default_edge.yml
@@ -1,31 +1,118 @@
 inherit_from: default.yml
 
+Layout/ClassStructure:
+  Enabled: true
+
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
 
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
+
 Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
   Enabled: true
 
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
 Lint/RaiseException:
+  Enabled: false
+
+Lint/SelfAssignment:
   Enabled: true
 
 Lint/StructNewOverride:
   Enabled: true
 
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
+Style/AccessorGrouping:
+  Enabled: true
+  EnforcedStyle: grouped
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/CaseLikeIf:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: true
+
 Style/ExponentialNotation:
+  Enabled: true
+  EnforcedStyle: scientific
+
+Style/GlobalStdStream:
+  Enabled: false
+
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+Style/HashLikeCase:
+  Enabled: true 
+  MinBranchesCount: 4
+
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false
+
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: false
+
+Style/RedundantFileExtensionInRequire:
   Enabled: false
 
 Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
   Enabled: false
 
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SingleArgumentDig:
+  Enabled: true
+
 Style/SlicingWithRange:
+  Enabled: false
+
+Style/StringConcatenation:
   Enabled: false

--- a/rubocop-rootstrap.gemspec
+++ b/rubocop-rootstrap.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   #
   # 0.72 removed rubocop-rails from the main rubocop project
   #
-  spec.add_runtime_dependency 'rubocop', ['>= 0.72', '<= 0.85']
+  spec.add_runtime_dependency 'rubocop', ['>= 0.72', '<= 0.89.0']
 
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9.0'


### PR DESCRIPTION
## Features
- Bump rubocop from 0.85 to 0.89.0
- Added missing config for new (and some existing) cops.
- Fixed some departments for existing cops config (Documentation, LineLength).