### PR TITLE
Updating rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,1 @@
-inherit_from: ./config/default.yml
+inherit_from: ./config/default_edge.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - bundle exec rake code_analysis
-  - bundle exec rspec
+  # # When adding a new cop, uncomment the lines below to analyze/test in the CI
+  # - bundle exec rake code_analysis
+  # - bundle exec rspec
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
+  - echo 'Nothing to run'
   # # When adding a new cop, uncomment the lines below to analyze/test in the CI
   # - bundle exec rake code_analysis
   # - bundle exec rspec

--- a/config/default_edge.yml
+++ b/config/default_edge.yml
@@ -1,5 +1,8 @@
 inherit_from: default.yml
 
+AllCops:
+  NewCops: enable
+
 Layout/ClassStructure:
   Enabled: true
 

--- a/rubocop-rootstrap.gemspec
+++ b/rubocop-rootstrap.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Rubocop with Rootstrap\'s code style'
   spec.homepage      = 'https://github.com/rootstrap/rubocop-rootstrap'
   spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.files = Dir['LICENSE.txt', 'README.md', 'lib/**/*', 'config/*.yml']
 

--- a/rubocop-rootstrap.gemspec
+++ b/rubocop-rootstrap.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   #
   # 0.72 removed rubocop-rails from the main rubocop project
   #
-  spec.add_runtime_dependency 'rubocop', ['>= 0.72', '<= 0.89.0']
+  spec.add_runtime_dependency 'rubocop', ['>= 0.72', '<= 1.2']
 
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'rubocop/cop/rootstrap'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Rubocop recently reached the first stable version 1.0 and they have
assured the community they'll follow semantic versioning from now on.

As of today, v1.2 has been released. This PR introduces support via the
gemspec up to that version and enables all new cops by default when
using the edge configuration.