### PR TITLE
[Upgrade] Allowing all rubocop v1 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ### Bug Fixes
 ### Changes
 
+# 1.2
+
+### Changes
+* rubocop-rootstrap now works with all v1 releases
+
 # 1.1
 
 ### New Features

--- a/rubocop-rootstrap.gemspec
+++ b/rubocop-rootstrap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-rootstrap'
-  spec.version       = '1.1'
+  spec.version       = '1.2'
   spec.authors       = ['Rootstrap']
   spec.email         = ['info@rootstrap.com']
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   #
   # 0.72 removed rubocop-rails from the main rubocop project
   #
-  spec.add_runtime_dependency 'rubocop', ['>= 0.72', '<= 1.2']
+  spec.add_runtime_dependency 'rubocop', ['>= 0.72', '< 2']
 
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9.0'


### PR DESCRIPTION
Given that rubocop now completely follows semantic versioning, minor and
patch changes shouldn't impact negatively on projects using
rubocop-rootstrap.